### PR TITLE
[4.0] Change \ to / in element field  to prevent installed libraries appearing in Extensions:Discover listing

### DIFF
--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -169,7 +169,12 @@ class DiscoverModel extends InstallerModel
 
 		foreach ($installedtmp as $install)
 		{
-			$key = implode(':', array($install->type, $install->element, $install->folder, $install->client_id));
+			$key = implode(':',
+				array(
+					$install->type,
+					str_replace('\\', '/', $install->element),
+					$install->folder,
+					$install->client_id));
 			$extensions[$key] = $install;
 		}
 
@@ -178,7 +183,12 @@ class DiscoverModel extends InstallerModel
 		foreach ($results as $result)
 		{
 			// Check if we have a match on the element
-			$key = implode(':', array($result->type, $result->element, $result->folder, $result->client_id));
+			$key = implode(':',
+				array(
+					$result->type,
+					str_replace('\\', '/', $result->element),
+					$result->folder,
+					$result->client_id));
 
 			if (!array_key_exists($key, $extensions))
 			{


### PR DESCRIPTION
Pull Request for Issue #35015 .

### Summary of Changes

Added str_replace() to change \ to /.
Looks like only the str_replace() at line 189 maybe essential but included one at line 175 for consistency and clarity.

### Testing Instructions

Use a MS Windows hosted test site (may not be a problem on Linux sites).
Install this library;
[lib_bftest1.zip](https://github.com/BrainforgeUK/joomla-cms/files/6913379/lib_bftest1.zip)

### Actual result BEFORE applying this Pull Request

The library installed correctly AND appears in the Extensions:Discover listing.
Can then be installed again from there - get 2 records in the extensions table!

Need to uninstall both before testing the patch.

### Expected result AFTER applying this Pull Request

The library installed correctly and does not appear in the Extensions:Discover listing.

### Documentation Changes Required

None.