### PR TITLE
Corrected 'could not copy files' message

### DIFF
--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -77,7 +77,7 @@ class LibraryAdapter extends InstallerAdapter
 	{
 		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
-			throw new \RuntimeException(Text::_('JLIB_INSTALLER_ABORT_LIB_COPY_FILES'));
+			throw new \RuntimeException(Text::sprintf('JLIB_INSTALLER_ABORT_LIB_COPY_FILES', $this->element));
 		}
 	}
 


### PR DESCRIPTION
Library %s: Could not copy files from the source.
Library element field was not being populated.

### Summary of Changes

Changed Text::_() to Text::sprintf() and added element to function call

### Testing Instructions

Install this package.
[lib_bftest1.zip](https://github.com/BrainforgeUK/joomla-cms/files/6990828/lib_bftest1.zip)

### Actual result BEFORE applying this Pull Request

Message displayed:
Library %s: Could not copy files from the source.

### Expected result AFTER applying this Pull Request

Message displayed:
Library brainforgeuk/test1: Could not copy files from the source.

### Documentation Changes Required

None