### PR TITLE
Update StyleModel.php

### DIFF
--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -396,9 +396,12 @@ class StyleModel extends AdminModel
         $formFile = Path::clean($client->path . '/templates/' . $template . '/templateDetails.xml');
 
         // Load the core and/or local language file(s).
+        // Default to using parent template language constants
+        $lang->load('tpl_' . $data->parent, $client->path)
+            || $lang->load('tpl_' . $data->parent, $client->path . '/templates/' . $data->parent);
+
+        // Apply any, optional, overrides for child template language constants
         $lang->load('tpl_' . $template, $client->path)
-            || (!empty($data->parent) && $lang->load('tpl_' . $data->parent, $client->path))
-            || (!empty($data->parent) && $lang->load('tpl_' . $data->parent, $client->path . '/templates/' . $data->parent))
             || $lang->load('tpl_' . $template, $client->path . '/templates/' . $template);
 
         if (file_exists($formFile)) {


### PR DESCRIPTION
Corrected language .ini file handling in child templates.

Pull Request for Issue #40660.

### Summary of Changes

Changed loading of the core and/or local language file(s).

### Testing Instructions

Install the following simple child templates.

[tpl_cassiopeia_test1.zip](https://github.com/BrainforgeUK/joomla-cms/files/11581302/tpl_cassiopeia_test1.zip)

[tpl_cassiopeia_test2.zip](https://github.com/BrainforgeUK/joomla-cms/files/11581303/tpl_cassiopeia_test2.zip)

### Actual result BEFORE applying this Pull Request

![actual-screenshot](https://github.com/BrainforgeUK/joomla-cms/assets/3941269/79f82f93-4cca-4cd0-a68b-863ba537667f)

### Expected result AFTER applying this Pull Request

![expected-screenshot](https://github.com/BrainforgeUK/joomla-cms/assets/3941269/c9d345ff-1bb6-4b3f-a41c-e0e77564913f)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [* ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ *] No documentation changes for manual.joomla.org needed