### PR TITLE
Update StyleModel.php

### DIFF
--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -396,10 +396,13 @@ class StyleModel extends AdminModel
         $formFile = Path::clean($client->path . '/templates/' . $template . '/templateDetails.xml');
 
         // Load the core and/or local language file(s).
-        $lang->load('tpl_' . $template, $client->path)
-            || (!empty($data->parent) && $lang->load('tpl_' . $data->parent, $client->path))
-            || (!empty($data->parent) && $lang->load('tpl_' . $data->parent, $client->path . '/templates/' . $data->parent))
-            || $lang->load('tpl_' . $template, $client->path . '/templates/' . $template);
+	    // Default to using parent template language constants
+	    $lang->load('tpl_' . $data->parent, $client->path)
+            || $lang->load('tpl_' . $data->parent, $client->path . '/templates/' . $data->parent);
+
+	    // Apply any, optional, overrides for child template language constants
+	    $lang->load('tpl_' . $template, $client->path)
+	        || $lang->load('tpl_' . $template, $client->path . '/templates/' . $template);
 
         if (file_exists($formFile)) {
             // Get the template form.


### PR DESCRIPTION
Corrected language .ini file handling with child templates.

Pull Request for Issue #40660 .

### Summary of Changes

Corrected loading of core and/or local language file(s) with child templates.

### Testing Instructions

Install the following simple child templates (test1 and test2).

[tpl_cassiopeia_test1.zip](https://github.com/BrainforgeUK/joomla-cms/files/11581344/tpl_cassiopeia_test1.zip)

[tpl_cassiopeia_test2.zip](https://github.com/BrainforgeUK/joomla-cms/files/11581345/tpl_cassiopeia_test2.zip)

### Actual result BEFORE applying this Pull Request

![actual-screenshot](https://github.com/BrainforgeUK/joomla-cms/assets/3941269/02ceaccd-719b-4549-a6a7-c57d4542292b)

### Expected result AFTER applying this Pull Request

![expected-screenshot](https://github.com/BrainforgeUK/joomla-cms/assets/3941269/958085af-fef6-4af6-92e3-480153fc80bf)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [*] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [*] No documentation changes for manual.joomla.org needed
